### PR TITLE
Make config initialization public

### DIFF
--- a/config.go
+++ b/config.go
@@ -123,7 +123,7 @@ type Config struct {
 }
 
 // Validate and update exporter configuration
-func (c *Config) validateAndUpdate() {
+func (c *Config) ValidateAndUpdate() {
 	if c.AeroProm.Bind == "" {
 		c.AeroProm.Bind = ":9145"
 	}
@@ -142,7 +142,7 @@ func (c *Config) validateAndUpdate() {
 }
 
 // Initialize exporter configuration
-func initConfig(configFile string, config *Config) {
+func InitConfig(configFile string, config *Config) {
 	// to print everything out regarding reading the config in app init
 	log.SetLevel(log.DebugLevel)
 

--- a/gauge_stats.go
+++ b/gauge_stats.go
@@ -30,7 +30,7 @@ type GaugeStats struct {
 }
 
 // Initialize exporter configuration
-func initGaugeStats(pGaugeStatsFile string, pGaugeStats *GaugeStats) {
+func InitGaugeStats(pGaugeStatsFile string, pGaugeStats *GaugeStats) {
 
 	log.Infof("Loading Gauge Stats file %s", pGaugeStatsFile)
 

--- a/gauge_stats_test.go
+++ b/gauge_stats_test.go
@@ -18,7 +18,7 @@ func TestGetGaugesNotEmpty(t *testing.T) {
 	// Initialize and validate Gauge config
 	gaugeList := new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeList)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeList)
 
 	nslist := gaugeList.NamespaceStats
 	nodelist := gaugeList.NodeStats
@@ -36,7 +36,7 @@ func TestGetGaugesCounts(t *testing.T) {
 	// Initialize and validate Gauge config
 	gaugeList := new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeList)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeList)
 
 	glist := gaugeList.NamespaceStats
 	assert.Equal(t, len(glist), 96)
@@ -63,7 +63,7 @@ func TestIsAGaugeTrue(t *testing.T) {
 	// Initialize and validate Gauge config
 	gaugeList := new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeList)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeList)
 
 	exists := false
 
@@ -94,7 +94,7 @@ func TestNoGaugeExists(t *testing.T) {
 	// Initialize and validate Gauge config
 	gaugeList := new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeList)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeList)
 
 	exists := gaugeList.isGauge(CTX_NAMESPACE, "non-existing-key")
 	assert.Equal(t, exists, false)

--- a/main.go
+++ b/main.go
@@ -48,19 +48,19 @@ func main() {
 	log.Infof("Welcome to Aerospike Prometheus Exporter %s", version)
 
 	config = new(Config)
-	initConfig(*configFile, config)
-	config.validateAndUpdate()
+	InitConfig(*configFile, config)
+	config.ValidateAndUpdate()
 
 	// initialize Gauge metric definitions
 	gaugeStatHandler = new(GaugeStats)
-	initGaugeStats(*gaugeStatsFile, gaugeStatHandler)
+	InitGaugeStats(*gaugeStatsFile, gaugeStatHandler)
 
 	fullHost = net.JoinHostPort(config.Aerospike.Host, strconv.Itoa(int(config.Aerospike.Port)))
 
 	host := aero.NewHost(config.Aerospike.Host, int(config.Aerospike.Port))
 	host.TLSName = config.Aerospike.NodeTLSName
 
-	observer, err := newObserver(host, config.Aerospike.User, config.Aerospike.Password)
+	observer, err := NewObserver(host, config.Aerospike.User, config.Aerospike.Password)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/observer.go
+++ b/observer.go
@@ -71,7 +71,7 @@ func initAerospikeTLS() *tls.Config {
 	return tlsConfig
 }
 
-func newObserver(server *aero.Host, user, pass string) (o *Observer, err error) {
+func NewObserver(server *aero.Host, user, pass string) (o *Observer, err error) {
 	// initialize aerospike_node_up metric descriptor
 	nodeActiveDesc = prometheus.NewDesc(
 		"aerospike_node_up",

--- a/watcher_latency_test.go
+++ b/watcher_latency_test.go
@@ -29,8 +29,8 @@ func TestLatencies_PassTwoKeys(t *testing.T) {
 	fmt.Println("initializing config ... TestLatencies_PassTwoKeys")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(DEFAULT_APE_TOML, config)
-	config.validateAndUpdate()
+	InitConfig(DEFAULT_APE_TOML, config)
+	config.ValidateAndUpdate()
 
 	watcher := new(LatencyWatcher)
 
@@ -50,8 +50,8 @@ func TestLatencies_RefreshDefault(t *testing.T) {
 	fmt.Println("initializing config ... TestLatencies_RefreshDefault")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(DEFAULT_APE_TOML, config)
-	config.validateAndUpdate()
+	InitConfig(DEFAULT_APE_TOML, config)
+	config.ValidateAndUpdate()
 
 	// run the test-case logic
 	latencies_runTestCase(t)
@@ -65,14 +65,14 @@ func TestLatencies_RefreshWithLabelsConfig(t *testing.T) {
 	fmt.Println("initializing config ... TestLatencies_RefreshWithLabelsConfig")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(LABELS_APE_TOML, config)
-	config.validateAndUpdate()
+	InitConfig(LABELS_APE_TOML, config)
+	config.ValidateAndUpdate()
 
 	watcher := new(LatencyWatcher)
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 	rawMetrics := getRawMetrics()
 
 	lObserver := &Observer{}
@@ -127,7 +127,7 @@ func latencies_runTestCase(t *testing.T) {
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 	rawMetrics := getRawMetrics()
 
 	lObserver := &Observer{}

--- a/watcher_namespaces_test.go
+++ b/watcher_namespaces_test.go
@@ -48,9 +48,9 @@ func TestNamespaceRefreshDefault(t *testing.T) {
 	fmt.Println("initializing config ... TestNamespaceRefreshDefault")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(DEFAULT_APE_TOML, config)
+	InitConfig(DEFAULT_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	runTestcase(t)
 	os.Setenv(TESTCASE_MODE, TESTCASE_MODE_FALSE)
@@ -64,9 +64,9 @@ func TestNamespaceRefreshLabels(t *testing.T) {
 	fmt.Println("initializing config ... TestNamespaceRefreshLabels")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(LABELS_APE_TOML, config)
+	InitConfig(LABELS_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	runTestcase(t)
 	os.Setenv(TESTCASE_MODE, TESTCASE_MODE_FALSE)
@@ -80,9 +80,9 @@ func TestNamespaceRefreshAllowlist(t *testing.T) {
 	fmt.Println("initializing config ... TestNamespaceRefreshAllowlist")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(NS_ALLOWLIST_APE_TOML, config)
+	InitConfig(NS_ALLOWLIST_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	runTestcase(t)
 
@@ -96,9 +96,9 @@ func TestNamespaceRefreshBlocklist(t *testing.T) {
 	fmt.Println("initializing config ... TestNamespaceRefreshBlocklist")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(NS_BLOCKLIST_APE_TOML, config)
+	InitConfig(NS_BLOCKLIST_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	runTestcase(t)
 
@@ -111,7 +111,7 @@ func runTestcase(t *testing.T) {
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 
 	// read raw-metrics from mock data gen, create observer and channel prometeus metric ingestion and processing
 	rawMetrics := getRawMetrics()

--- a/watcher_node_stats_test.go
+++ b/watcher_node_stats_test.go
@@ -38,9 +38,9 @@ func TestNodeStats_RefreshDefault(t *testing.T) {
 	fmt.Println("initializing config ... TestNodeStats_RefreshDefault")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(DEFAULT_APE_TOML, config)
+	InitConfig(DEFAULT_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	// run the test-case logic
 	nodeStats_runTestCase(t)
@@ -54,9 +54,9 @@ func TestNodeStats_Allowlist(t *testing.T) {
 	fmt.Println("initializing config ... TestNodeStats_Allowlist")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(NS_ALLOWLIST_APE_TOML, config)
+	InitConfig(NS_ALLOWLIST_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	// run the test-case logic
 	nodeStats_runTestCase(t)
@@ -70,9 +70,9 @@ func TestNodeStats_Blocklist(t *testing.T) {
 	fmt.Println("initializing config ... TestNodeStats_Blocklist")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(NS_BLOCKLIST_APE_TOML, config)
+	InitConfig(NS_BLOCKLIST_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	// run the test-case logic
 	nodeStats_runTestCase(t)
@@ -88,7 +88,7 @@ func nodeStats_runTestCase(t *testing.T) {
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 	rawMetrics := getRawMetrics()
 
 	lObserver := &Observer{}

--- a/watcher_sets_test.go
+++ b/watcher_sets_test.go
@@ -38,9 +38,9 @@ func TestSets_RefreshDefault(t *testing.T) {
 	fmt.Println("initializing config ... TestSets_RefreshDefault")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(DEFAULT_APE_TOML, config)
+	InitConfig(DEFAULT_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	// run the test-case logic
 	sets_runTestCase(t)
@@ -54,9 +54,9 @@ func TestSets_Allowlist(t *testing.T) {
 	fmt.Println("initializing config ... TestSets_Allowlist")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(NS_ALLOWLIST_APE_TOML, config)
+	InitConfig(NS_ALLOWLIST_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	// run the test-case logic
 	sets_runTestCase(t)
@@ -70,14 +70,14 @@ func TestSets_RefreshWithLabelsConfig(t *testing.T) {
 	fmt.Println("initializing config ... TestSets_RefreshWithLabelsConfig")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(LABELS_APE_TOML, config)
-	config.validateAndUpdate()
+	InitConfig(LABELS_APE_TOML, config)
+	config.ValidateAndUpdate()
 
 	watcher := new(SetWatcher)
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 	rawMetrics := getRawMetrics()
 
 	lObserver := &Observer{}
@@ -132,7 +132,7 @@ func sets_runTestCase(t *testing.T) {
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 	rawMetrics := getRawMetrics()
 
 	lObserver := &Observer{}

--- a/watcher_sindex_test.go
+++ b/watcher_sindex_test.go
@@ -16,8 +16,8 @@ func TestSindex_PassOneKeys(t *testing.T) {
 	watcher := new(SindexWatcher)
 
 	config = new(Config)
-	initConfig(LABELS_APE_TOML, config)
-	config.validateAndUpdate()
+	InitConfig(LABELS_APE_TOML, config)
+	config.ValidateAndUpdate()
 
 	// Check passoneKeys
 	passOneKeysOutputs := watcher.passOneKeys()
@@ -48,9 +48,9 @@ func TestSindex_RefreshDefault(t *testing.T) {
 	fmt.Println("initializing config ... TestSindex_RefreshDefault")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(DEFAULT_APE_TOML, config)
+	InitConfig(DEFAULT_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	// run the test-case logic
 	sindex_runTestCase(t)
@@ -64,9 +64,9 @@ func TestSindex_Allowlist(t *testing.T) {
 	fmt.Println("initializing config ... TestSets_Allowlist")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(NS_ALLOWLIST_APE_TOML, config)
+	InitConfig(NS_ALLOWLIST_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	// run the test-case logic
 	sindex_runTestCase(t)
@@ -80,14 +80,14 @@ func TestSindex_RefreshWithLabelsConfig(t *testing.T) {
 	fmt.Println("initializing config ... TestSindex_RefreshWithLabelsConfig")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(LABELS_APE_TOML, config)
-	config.validateAndUpdate()
+	InitConfig(LABELS_APE_TOML, config)
+	config.ValidateAndUpdate()
 
 	watcher := new(SindexWatcher)
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 	rawMetrics := getRawMetrics()
 
 	lObserver := &Observer{}
@@ -143,7 +143,7 @@ func sindex_runTestCase(t *testing.T) {
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 	rawMetrics := getRawMetrics()
 
 	lObserver := &Observer{}

--- a/watcher_users_test.go
+++ b/watcher_users_test.go
@@ -39,8 +39,8 @@ func TestUsers_Allowlist(t *testing.T) {
 	fmt.Println("initializing config ... TestUsers_Allowlist")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(NS_ALLOWLIST_APE_TOML, config)
-	config.validateAndUpdate()
+	InitConfig(NS_ALLOWLIST_APE_TOML, config)
+	config.ValidateAndUpdate()
 
 	// this is required as UserWatcher cheks for user/password in the properties file
 	config.Aerospike.User = "admin"
@@ -48,7 +48,7 @@ func TestUsers_Allowlist(t *testing.T) {
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 
 	users_runTestCase(t)
 }
@@ -59,8 +59,8 @@ func TestUsers_RefreshWithLabelsConfig(t *testing.T) {
 	fmt.Println("initializing config ... TestUsers_RefreshWithLabelsConfig")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(LABELS_APE_TOML, config)
-	config.validateAndUpdate()
+	InitConfig(LABELS_APE_TOML, config)
+	config.ValidateAndUpdate()
 
 	watcher := new(UserWatcher)
 
@@ -70,7 +70,7 @@ func TestUsers_RefreshWithLabelsConfig(t *testing.T) {
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 	rawMetrics := getRawMetrics()
 
 	lObserver := &Observer{}
@@ -129,7 +129,7 @@ func users_runTestCase(t *testing.T) {
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 	rawMetrics := getRawMetrics()
 
 	lObserver := &Observer{}

--- a/watcher_xdr_test.go
+++ b/watcher_xdr_test.go
@@ -43,14 +43,14 @@ func TestXdr_RefreshWithLabelsConfig(t *testing.T) {
 	fmt.Println("initializing config ... TestXdr_RefreshWithLabelsConfig")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(LABELS_APE_TOML, config)
-	config.validateAndUpdate()
+	InitConfig(LABELS_APE_TOML, config)
+	config.ValidateAndUpdate()
 
 	watcher := new(XdrWatcher)
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 	rawMetrics := getRawMetrics()
 
 	lObserver := &Observer{}
@@ -105,8 +105,8 @@ func TestXdr_RefreshDefault(t *testing.T) {
 	fmt.Println("initializing config ... TestXdr_RefreshDefault")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(DEFAULT_APE_TOML, config)
-	config.validateAndUpdate()
+	InitConfig(DEFAULT_APE_TOML, config)
+	config.ValidateAndUpdate()
 
 	xdr_runTestCase(t)
 
@@ -118,9 +118,9 @@ func TestXdr_Allowlist(t *testing.T) {
 	fmt.Println("initializing config ... TestXdr_Allowlist")
 	// Initialize and validate config
 	config = new(Config)
-	initConfig(NS_ALLOWLIST_APE_TOML, config)
+	InitConfig(NS_ALLOWLIST_APE_TOML, config)
 
-	config.validateAndUpdate()
+	config.ValidateAndUpdate()
 
 	// run the test-case logic
 	xdr_runTestCase(t)
@@ -136,7 +136,7 @@ func xdr_runTestCase(t *testing.T) {
 
 	gaugeStatHandler = new(GaugeStats)
 
-	initGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
+	InitGaugeStats(METRICS_CONFIG_FILE, gaugeStatHandler)
 	rawMetrics := getRawMetrics()
 
 	lObserver := &Observer{}


### PR DESCRIPTION
This update to the aerospike-prometheus-exporter makes the functions involved in creating a config public. This change is made to allow the exporter to be integrated with the Grafana agent.
Functions changed to be public are:
- InitConfig()
- InitGaugeStats()
- ValidateAndUpdate()
- NewObserver()